### PR TITLE
Added support for bundler

### DIFF
--- a/lib/build-rake.coffee
+++ b/lib/build-rake.coffee
@@ -15,11 +15,17 @@ exports.provideRakeBuilder = ->
       found = files.map (file) => path.join(@cwd, file)
         .filter(fs.existsSync)
 
+      gemfiles = ['Gemfile', 'Gemfile.lock']
+      gemfilesFound = files.map (file) => path.join(@cwd, file)
+        .filter(fs.existsSync)
+      @useBundler = (gemfilesFound.length > 0)
+
       found.length > 0
 
     settings: ->
       new Promise (resolve, reject) =>
         rake_exec = if /^win/.test(process.platform) then "rake.bat" else "rake"
+        rake_exec = "bundle exec #{rake_exec}" if @useBundler
         rake_t    = "#{rake_exec} -T"
         child_process.exec rake_t, {cwd: @cwd}, (error, stdout, stderr) ->
           reject(error) if error?


### PR DESCRIPTION
It now prepends 'bundle exec' if a Gemfile/Gemfile.lock can be found in the root folder.

Should be made optional, but I really don't know how to do that :)
